### PR TITLE
Updated for Scala 2.10.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ startYear := Some(2011)
 
 licenses := Seq("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 
-scalaVersion := "2.10.0"
+scalaVersion := "2.10.1"
 
 scalacOptions <<= scalaVersion map {
   case x if x startsWith "2.9" =>
@@ -37,7 +37,7 @@ libraryDependencies ++= Seq(
 // publishing
 ///////////////
 
-crossScalaVersions := Seq("2.9.2", "2.10.0")
+crossScalaVersions := Seq("2.9.2", "2.10.1")
 
 scalaBinaryVersion <<= scalaVersion(sV => if (CrossVersion.isStable(sV)) CrossVersion.binaryScalaVersion(sV) else sV)
 


### PR DESCRIPTION
I've updated the build file for Scala 2.10.0, including the dependencies.  However, I don't have all of the tests passing.  It appears that I need .testhost configured to have a valid test environment.
