### PR TITLE
Adding SFTP and SCP capabilities

### DIFF
--- a/src/main/scala/com/decodified/scalassh/ScpTransferable.scala
+++ b/src/main/scala/com/decodified/scalassh/ScpTransferable.scala
@@ -1,0 +1,50 @@
+package com.decodified.scalassh
+
+import net.schmizz.sshj.sftp.SFTPClient
+import net.schmizz.sshj.xfer.scp.SCPFileTransfer
+import net.schmizz.sshj.xfer.TransferListener
+import net.schmizz.sshj.xfer.LoggingTransferListener
+
+trait ScpTransferable {
+  self: SshClient =>
+
+  def sftp[T](fun: SFTPClient => T) = {
+    authenticatedClient.right.flatMap {
+      client =>
+      startSession(client).right.flatMap {
+        session =>
+        protect("SFTP client failed") {
+          val ftpClient = client.newSFTPClient()
+          try {
+            fun(ftpClient)
+          } finally {
+            ftpClient.close()
+          }
+        }
+      }
+    }
+  }
+
+  def fileTransfer(fun: SCPFileTransfer => Unit)(implicit listener: TransferListener = new LoggingTransferListener()) = {
+    authenticatedClient.right.flatMap {
+      client =>
+      startSession(client).right.flatMap {
+        session =>
+        protect("SCP file transfer failed") {
+          val transfer = client.newSCPFileTransfer()
+          transfer.setTransferListener(listener)
+          fun(transfer)
+          this
+        }
+      }
+    }
+  }
+
+  def upload(localPath: String, remotePath: String)(implicit listener: TransferListener = new LoggingTransferListener()) = {
+    fileTransfer(_.upload(localPath, remotePath))(listener)
+  }
+
+  def download(remotePath: String, localPath: String)(implicit listener: TransferListener = new LoggingTransferListener()) = {
+    fileTransfer(_.download(remotePath, localPath))(listener)
+  }
+}

--- a/src/main/scala/com/decodified/scalassh/package.scala
+++ b/src/main/scala/com/decodified/scalassh/package.scala
@@ -18,6 +18,9 @@ package com.decodified
 
 package object scalassh {
   type Validated[T] = Either[String, T]
+  class RichSshClient(sshClient: SshClient) extends SshClient(sshClient.config) with ScpTransferable
 
   def make[A, U](a: A)(f: A => U): A = { f(a); a }
+
+  implicit def sshClientToRichClient(sshClient: SshClient) = new RichSshClient(sshClient)
 }


### PR DESCRIPTION
I've added SFTP and SCP capabilities to the SshClient via rich implicit conversion, but these capabilities could easily be moved into the SshClient class.

If the latter is a more preferable change, I can make that change really quick. 
