### PR TITLE
Fix possible runtime exception

### DIFF
--- a/src/main/scala/com/decodified/scalassh/HostConfig.scala
+++ b/src/main/scala/com/decodified/scalassh/HostConfig.scala
@@ -161,7 +161,7 @@ object HostFileConfig {
       locations.find(_.exists) match {
         case Some(file) =>
           try Right(file.getAbsolutePath -> Source.fromFile(file, "utf8").getLines())
-          catch { case e: IOException => Left("Could not read host file '%' due to %s".format(file, e)) }
+          catch { case e: IOException => Left("Could not read host file '%s' due to %s".format(file, e)) }
         case None =>
           Left(("Host files '%s' not found, either provide one or use a concrete HostConfig, PasswordLogin or " +
             "PublicKeyLogin").format(locations.mkString("', '")))


### PR DESCRIPTION
I've tried [Linter](https://github.com/HairyFotr/linter) on scala-ssh and found and fixed this possible runtime exception:

```
[warn] /home/hairy/dev/others/scala-ssh/src/main/scala/com/decodified/scalassh/HostConfig.scala:164: This string format will fail with: Conversion = '''
[warn]           catch { case e: IOException => Left("Could not read host file '%' due to %s".format(file, e)) }
[warn]                                               ^
```
