### PR TITLE
Agent login feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ It builds on SSHJ_ to provide the following features:
 
 * Remote execution of one or more shell commands
 * Access to ``stdin``, ``stdout``, ``stderr`` and exitcode of remote shell commands
-* Authentication via password or public key
+* Authentication via password, public key or agent
 * Host key verification via ``known_hosts`` file or explicit fingerprint
 * Convenient configuration of remote host properties via config file, resource or directly in code
 * Scala-idiomatic API

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import scalariform.formatter.preferences._
 
 name := "scala-ssh"
 
-version := "0.7.0"
+version := "0.7.1-SNAPSHOT"
 
 organization := "com.decodified"
 
@@ -16,7 +16,7 @@ startYear := Some(2011)
 
 licenses := Seq("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.10.4"
 
 scalacOptions ++= Seq("-feature", "-language:implicitConversions", "-unchecked", "-deprecation", "-encoding", "utf8")
 
@@ -25,6 +25,8 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.7",
   "org.bouncycastle" % "bcprov-jdk16" % "1.46" % "provided",
   "com.jcraft" % "jzlib" % "1.1.3" % "provided",
+  "com.jcraft" % "jsch.agentproxy.sshj" % "0.0.8",
+  "com.jcraft" % "jsch.agentproxy.connector-factory" % "0.0.8",
   "ch.qos.logback" % "logback-classic" % "1.1.2" % "test",
   "org.specs2" %% "specs2" % "2.4.6" % "test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ startYear := Some(2011)
 
 licenses := Seq("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.2"
 
 scalacOptions ++= Seq("-feature", "-language:implicitConversions", "-unchecked", "-deprecation", "-encoding", "utf8")
 

--- a/src/main/scala/com/decodified/scalassh/SshLogin.scala
+++ b/src/main/scala/com/decodified/scalassh/SshLogin.scala
@@ -38,3 +38,10 @@ object PublicKeyLogin {
   def apply(user: String, passProducer: PasswordProducer, keyfileLocations: List[String]): PublicKeyLogin =
     PublicKeyLogin(user, Some(passProducer), keyfileLocations)
 }
+
+case class AgentLogin(user: String, host: String) extends SshLogin
+
+object AgentLogin {
+  def apply(): AgentLogin = AgentLogin(System.getProperty("user.name"), "localhost")
+  def apply(user: String): AgentLogin = AgentLogin(user, "localhost")
+}

--- a/src/test/resources/agent.com
+++ b/src/test/resources/agent.com
@@ -1,0 +1,4 @@
+# test host file
+login-type = agent
+username = bob
+enable-compression = yes

--- a/src/test/scala/com/decodified/scalassh/HostFileConfigSpec.scala
+++ b/src/test/scala/com/decodified/scalassh/HostFileConfigSpec.scala
@@ -30,9 +30,12 @@ class HostFileConfigSpec extends Specification {
     "encrypted PublicKeyLogin" ! {
       config("enc-keyfile.com") === Right(HostConfig(PublicKeyLogin("alice", "superSecure", "/some/file" :: Nil), "enc-keyfile.com"))
     }
+    "AgentLogin" ! {
+      config("agent.com") === Right(HostConfig(AgentLogin("bob"), "agent.com", enableCompression = true))
+    }
     "error message if the file is missing" ! {
       config("non-existing.com").left.get === "Host resources 'non-existing.com', 'com' not found, either " +
-        "provide one or use a concrete HostConfig, PasswordLogin or PublicKeyLogin"
+        "provide one or use a concrete HostConfig, PasswordLogin, PublicKeyLogin or AgentLogin"
     }
     "error message if the login-type is invalid" ! {
       config("invalid-login-type.com").left.get must startingWith("Illegal login-type setting 'fancy pants'")

--- a/src/test/scala/com/decodified/scalassh/HostFileConfigSpec.scala
+++ b/src/test/scala/com/decodified/scalassh/HostFileConfigSpec.scala
@@ -34,7 +34,7 @@ class HostFileConfigSpec extends Specification {
       config("agent.com") === Right(HostConfig(AgentLogin("bob"), "agent.com", enableCompression = true))
     }
     "error message if the file is missing" ! {
-      config("non-existing.com").left.get === "Host resources 'non-existing.com', 'com' not found, either " +
+      config("non-existing.net").left.get === "Host resources 'non-existing.net', 'net' not found, either " +
         "provide one or use a concrete HostConfig, PasswordLogin, PublicKeyLogin or AgentLogin"
     }
     "error message if the login-type is invalid" ! {


### PR DESCRIPTION
I've added agent login feature as provided by the [jcraft jsch agent proxy library](https://github.com/ymnk/jsch-agent-proxy) which [supports sshj](https://github.com/ymnk/jsch-agent-proxy/tree/master/jsch-agent-proxy-sshj)
This allows login with ssh-agent on *nix and Pageant on windows systems
