### PR TITLE
Fix connection hanging after upload/download

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import scalariform.formatter.preferences._
 
 name := "scala-ssh"
 
-version := "0.7.0"
+version := "0.7.1"
 
 organization := "com.decodified"
 
@@ -16,12 +16,12 @@ startYear := Some(2011)
 
 licenses := Seq("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.11.6"
 
 scalacOptions ++= Seq("-feature", "-language:implicitConversions", "-unchecked", "-deprecation", "-encoding", "utf8")
 
 libraryDependencies ++= Seq(
-  "net.schmizz" % "sshj" % "0.10.0",
+  "com.hierynomus" % "sshj" % "0.12.0",
   "org.slf4j" % "slf4j-api" % "1.7.7",
   "org.bouncycastle" % "bcprov-jdk16" % "1.46" % "provided",
   "com.jcraft" % "jzlib" % "1.1.3" % "provided",

--- a/src/main/scala/com/decodified/scalassh/SshClient.scala
+++ b/src/main/scala/com/decodified/scalassh/SshClient.scala
@@ -24,7 +24,7 @@ import net.schmizz.sshj.connection.channel.direct.Session
 import net.schmizz.sshj.userauth.keyprovider.KeyProvider
 import scala.io.Source
 
-class SshClient(val config: HostConfig) {
+class SshClient(val config: HostConfig) extends ScpTransferable {
   lazy val log = LoggerFactory.getLogger(getClass)
   lazy val endpoint = config.hostName + ':' + config.port
   lazy val authenticatedClient = connect(client).right.flatMap(authenticate)

--- a/src/main/scala/com/decodified/scalassh/package.scala
+++ b/src/main/scala/com/decodified/scalassh/package.scala
@@ -18,9 +18,6 @@ package com.decodified
 
 package object scalassh {
   type Validated[T] = Either[String, T]
-  class RichSshClient(sshClient: SshClient) extends SshClient(sshClient.config) with ScpTransferable
 
   def make[A, U](a: A)(f: A ⇒ U): A = { f(a); a }
-
-  implicit def sshClientToRichClient(sshClient: SshClient) = new RichSshClient(sshClient)
 }


### PR DESCRIPTION
Fixes issue #20 caused by implicit conversion of `SshClient` to `RichSshClient` that creates new `SshClient` instance without cleaning up after previous one.

The problem is the changes are not backwards-compatible because I removed `RichSshClient`, `SshClient` should be used instead. 