### PR TITLE
Bump SSHJ to 0.26.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ scalafmtOnCompile := true
 scalafmtVersion := "1.4.0"
 
 libraryDependencies ++= Seq(
-  "com.hierynomus" % "sshj"                              % "0.23.0",
+  "com.hierynomus" % "sshj"                              % "0.26.0",
   "org.slf4j"      % "slf4j-api"                         % "1.7.25",
   "com.jcraft"     % "jsch.agentproxy.sshj"              % "0.0.9" % "provided",
   "com.jcraft"     % "jsch.agentproxy.connector-factory" % "0.0.9" % "provided",


### PR DESCRIPTION
SSHJ 0.23.0 depends on bouncycastle 1.56, which is subject to the following vulnerabilities:

https://nvd.nist.gov/vuln/detail/CVE-2018-1000180
https://nvd.nist.gov/vuln/detail/CVE-2018-1000613

Bumping to 0.26.0 would fix these transitive issues.